### PR TITLE
Fix: Add warning about heredoc syntax in execute-command tool descrip…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -228,7 +228,7 @@ server.tool(
 // Execute command in pane - Tool
 server.tool(
   "execute-command",
-  "Execute a command in a tmux pane and get results",
+  "Execute a command in a tmux pane and get results. IMPORTANT: Avoid heredoc syntax (cat << EOF) and other multi-line constructs as they conflict with command wrapping. For file writing, prefer: printf 'content\\n' > file, echo statements, or write to temp files instead.",
   {
     paneId: z.string().describe("ID of the tmux pane"),
     command: z.string().describe("Command to execute")


### PR DESCRIPTION
(this PR generated with copious help from Claude.)

The execute-command tool wraps user commands with start/end markers using semicolon separation, which breaks heredoc syntax (cat << EOF) and other multi-line shell constructs. This change adds a clear warning in the tool description to guide LLMs away from using heredoc syntax and suggests alternative approaches for file writing operations.

This prevents command execution failures when LLMs attempt to use heredoc syntax, providing better user experience and clearer expectations for tool usage across different LLM implementations.

Decided to "fix" this by advising the prompt built into the MCP instructions, rather than trying to fix every weird shell edge case that might trigger it.
