### PR TITLE
sync: Merge all upstream changes (v0.1.1 → v0.2.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Model Context Protocol (MCP) server that enables interaction with tmux sessions. It provides tools and resources for reading terminal content, executing commands, and managing tmux sessions/windows/panes.
+
+## Development Commands
+
+```bash
+# Install dependencies
+npm install
+
+# Build the TypeScript code
+npm run build
+
+# Development mode (watch for changes)
+npm run dev
+
+# Run the compiled server
+npm start
+
+# Quick run via npx (no installation needed)
+npx -y tmux-mcp
+```
+
+## Architecture
+
+### Core Components
+
+1. **MCP Server (`src/index.ts`)**
+   - Implements the MCP protocol using `@modelcontextprotocol/sdk`
+   - Exposes tools for tmux operations (list sessions, execute commands, etc.)
+   - Provides resources for dynamic content (pane content, command results)
+   - Tracks command executions with UUIDs
+
+2. **tmux Integration (`src/tmux.ts`)**
+   - Wraps tmux CLI commands with TypeScript promises
+   - Key functions:
+     - `getSessions()`: Returns all tmux sessions
+     - `getWindows(sessionName)`: Returns windows in a session
+     - `getPanes(sessionName, windowIndex)`: Returns panes in a window
+     - `capturePane(paneId, lines)`: Captures pane content
+     - `executeCommand(paneId, command, shellType)`: Executes commands with tracking
+   - Implements command tracking using shell-specific markers (bash/zsh/fish)
+
+### Key Design Patterns
+
+- **Command Execution Tracking**: Commands are wrapped with unique markers to track their start/end and capture exit codes
+- **Resource URIs**: Uses `tmux://` protocol for resource identification
+- **Async Operations**: All tmux interactions are promise-based
+- **Shell Compatibility**: Supports bash, zsh, and fish shells with appropriate command markers
+
+## Important Implementation Details
+
+### Command Execution Flow
+
+1. Command is wrapped with unique markers (UUID-based)
+2. Sent to tmux pane via `send-keys`
+3. Result retrieval captures content between markers
+4. Exit code is extracted based on shell type
+
+### Resource Subscription
+
+The server supports subscribing to:
+- Pane content changes (`tmux://pane/{paneId}`)
+- Command execution results (`tmux://command/{commandId}/result`)
+
+### Security Considerations
+
+- Commands are executed directly without sanitization
+- The server has full access to all tmux sessions
+- Users should be aware of the security implications
+
+## Configuration
+
+The server accepts a `--shell-type` argument (defaults to `bash`):
+- `bash`
+- `zsh`
+- `fish`
+
+This affects how command exit codes are captured.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tmux-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tmux-mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.2",


### PR DESCRIPTION
## Summary

本家nickgnd/tmux-mcpから17個のコミット（16個の機能追加・改善 + 1個のリリース）をすべて取り込みます。

主な機能追加:
• ✨ **noEnterモード**: TUIアプリ（vim, btop, less等）との適切なインタラクション
• 🗑️ **kill機能**: tmuxセッション、ウィンドウ、ペインの削除ツール
• 📱 **ペイン分割**: 垂直・水平でのペイン分割機能
• 🎨 **色付きキャプチャ**: ペインキャプチャ時の色情報保持
• ⚡ **rawModeパラメータ**: インタラクティブコマンド実行のサポート
• 🚀 **起動改善**: tmuxが起動していなくてもMCPサーバーが起動可能に

バージョン: v0.1.1 → v0.2.2

## Test plan

- [x] TypeScriptビルドの成功
- [x] 型チェックの通過  
- [x] サーバー起動確認
- [x] パッケージ依存関係の解決

🤖 Generated with [Claude Code](https://claude.ai/code)