### PR TITLE
Use tmux on remote hosts (over SSH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,25 @@ You can optionally specify the command line shell you are using, if unspecified 
 
 The MCP server needs to know the shell only when executing commands, to properly read its exit status.
 
+## Remote execution
+
+In case the `tmux` session is running on another machine, you may tunnel your `tmux`
+commands over ssh, assuming you set up passwordless login, e.g., via SSH keys
+to the remote machine.
+
+To tunnel over SSH, add the `--ssh user@host` argument to the Claude configuration:
+```
+"mcpServers": {
+  "tmux": {
+    "command": "npx",
+    "args": ["-y", "tmux-mcp", "--ssh=user@host"]
+  }
+}
+```
+
+assuming that `ssh user@host` logs into the remote system without any interactive prompts.
+Please note that this has only been tested with `bash` on both sides.
+
 ## Available Resources
 
 - `tmux://sessions` - List all tmux sessions

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The MCP server needs to know the shell only when executing commands, to properly
 ## Remote execution
 
 In case the `tmux` session is running on another machine, you may tunnel your `tmux`
-commands over ssh, assuming you set up passwordless login, e.g., via SSH keys
+commands over ssh, assuming you set up non-interactive login, e.g., via SSH keys
 to the remote machine.
 
 To tunnel over SSH, add the `--ssh user@host` argument to the Claude configuration:
@@ -71,6 +71,9 @@ To tunnel over SSH, add the `--ssh user@host` argument to the Claude configurati
 
 assuming that `ssh user@host` logs into the remote system without any interactive prompts.
 Please note that this has only been tested with `bash` on both sides.
+
+You may need to pass further parts of the SSH commands here, e.g. `-i <path to your SSH key>`
+although, for brevity, we recommend using the `~/.ssh/config`.
 
 ## Available Resources
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -611,7 +611,8 @@ async function main() {
   try {
     const { values } = parseArgs({
       options: {
-        'shell-type': { type: 'string', default: 'bash', short: 's' }
+        'shell-type': { type: 'string', default: 'bash', short: 's' },
+        'ssh': { type: 'string', default: undefined, short: 'h'}
       }
     });
 
@@ -619,6 +620,10 @@ async function main() {
     tmux.setShellConfig({
       type: values['shell-type'] as string
     });
+
+    // enable remote access by prepending the executing tmux commands over SSH
+    if(values.ssh)
+      tmux.setSSHPrefix(values['ssh'])
 
     // Start the MCP server
     const transport = new StdioServerTransport();

--- a/src/index.ts
+++ b/src/index.ts
@@ -612,7 +612,7 @@ async function main() {
     const { values } = parseArgs({
       options: {
         'shell-type': { type: 'string', default: 'bash', short: 's' },
-        'ssh': { type: 'string', default: undefined, short: 'h'}
+        'ssh': { type: 'string', default: undefined, short: 'r'}
       }
     });
 

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -53,8 +53,8 @@ export function setShellConfig(config: { type: string }): void {
   }
 }
 
-export function setSSHPrefix(conn_str: string): void {
-  sshPrefix = `ssh ${conn_str} `
+export function setSSHPrefix(connectionString: string): void {
+  sshPrefix = `ssh ${connectionString} `
 }
 
 /**

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -40,6 +40,7 @@ interface CommandExecution {
 export type ShellType = 'bash' | 'zsh' | 'fish';
 
 let shellConfig: { type: ShellType } = { type: 'bash' };
+let sshPrefix : string = "";
 
 export function setShellConfig(config: { type: string }): void {
   // Validate shell type
@@ -52,12 +53,22 @@ export function setShellConfig(config: { type: string }): void {
   }
 }
 
+export function setSSHPrefix(conn_str: string): void {
+  sshPrefix = `ssh ${conn_str} `
+}
+
 /**
  * Execute a tmux command and return the result
  */
 export async function executeTmux(tmuxCommand: string): Promise<string> {
   try {
-    const { stdout } = await exec(`tmux ${tmuxCommand}`);
+    let command = `tmux ${tmuxCommand}`;
+    if(sshPrefix)
+    {
+      command = command.replaceAll("'", "'\\''");
+      command = `${sshPrefix} '${command}'`;
+    }
+    const { stdout } = await exec(command);
     return stdout.trim();
   } catch (error: any) {
     throw new Error(`Failed to execute tmux command: ${error.message}`);


### PR DESCRIPTION
Thank you so much for this cool MCP server! 

As an avid `tmux` user, this is right up my alley. At work, I often use `tmux` over SSH to work on remote machines, so a small extension to your MCP seemed the easiest way.