### PR TITLE
feat: add execute-command-wait tool for synchronous command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,5 +73,6 @@ The MCP server needs to know the shell only when executing commands, to properly
 - `kill-window` - Kill a tmux window by ID
 - `kill-pane` - Kill a tmux pane by ID
 - `execute-command` - Execute a command in a tmux pane
+- `execute-command-wait` - Execute a command and wait for its result in a single call
 - `get-command-result` - Get the result of an executed command
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -390,6 +390,49 @@ server.tool(
   }
 );
 
+// Execute command and wait for result - Tool
+server.tool(
+  "execute-command-wait",
+  "Execute a command in a tmux pane and wait synchronously for its completion in a single MCP call. Returns the final status, exit code and output directly — no need to poll 'get-command-result' afterwards. Use this for short, non-interactive commands where you want the result immediately (e.g. `ls`, `git status`, quick builds). Prefer the async pair 'execute-command' + 'get-command-result' for long-running commands (the MCP call blocks until completion or timeout), and for interactive apps / REPLs / TUI navigation (use 'execute-command' with rawMode or noEnter instead, since status tracking is unavailable in those modes). If the timeout elapses before completion, the response reports status 'pending' and returns the Command ID so you can keep polling with 'get-command-result'.",
+  {
+    paneId: z.string().describe("ID of the tmux pane"),
+    command: z.string().describe("Command to execute. Avoid heredoc (cat << EOF) and multi-line constructs — they conflict with the start/end markers used for status tracking. Prefer: printf 'line1\\nline2\\n' > file, echo statements, or write to a temp file."),
+    timeout: z.number().min(1).max(600).optional().describe("Maximum time to wait for completion, in seconds. Default: 30. Max: 600 (10 min). If exceeded, the tool returns with status 'pending' and the command keeps running in the pane."),
+    pollInterval: z.number().min(50).max(5000).optional().describe("Polling interval in milliseconds while waiting. Default: 500. Lower values give faster response but more tmux calls.")
+  },
+  async ({ paneId, command, timeout, pollInterval }) => {
+    try {
+      const timeoutMs = (timeout ?? 30) * 1000;
+      const pollMs = pollInterval ?? 500;
+
+      const result = await tmux.executeCommandAndWait(paneId, command, timeoutMs, pollMs);
+
+      let resultText: string;
+      if (result.status === 'pending') {
+        const resourceUri = `tmux://command/${result.id}/result`;
+        resultText = `Status: pending (timeout of ${timeout ?? 30}s reached)\nCommand: ${result.command}\nCommand ID: ${result.id}\n\nThe command is still running in the pane. Poll 'get-command-result' with this Command ID, or read resource ${resourceUri}, to retrieve the final output.`;
+      } else {
+        resultText = `Status: ${result.status}\nExit code: ${result.exitCode}\nCommand: ${result.command}\n\n--- Output ---\n${result.result ?? ''}`;
+      }
+
+      return {
+        content: [{
+          type: "text",
+          text: resultText
+        }]
+      };
+    } catch (error) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error executing command: ${error}`
+        }],
+        isError: true
+      };
+    }
+  }
+);
+
 // Get command result - Tool
 server.tool(
   "get-command-result",

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -338,6 +338,32 @@ export function getCommand(commandId: string): CommandExecution | null {
   return activeCommands.get(commandId) || null;
 }
 
+export async function executeCommandAndWait(
+  paneId: string,
+  command: string,
+  timeoutMs: number = 30000,
+  pollIntervalMs: number = 500
+): Promise<CommandExecution> {
+  const commandId = await executeCommand(paneId, command, false, false);
+
+  const deadline = Date.now() + timeoutMs;
+
+  while (true) {
+    const status = await checkCommandStatus(commandId);
+
+    if (status && status.status !== 'pending') {
+      return status;
+    }
+
+    if (Date.now() >= deadline) {
+      return status ?? (activeCommands.get(commandId) as CommandExecution);
+    }
+
+    const remaining = deadline - Date.now();
+    await new Promise(resolve => setTimeout(resolve, Math.min(pollIntervalMs, remaining)));
+  }
+}
+
 // Get all active command IDs
 export function getActiveCommandIds(): string[] {
   return Array.from(activeCommands.keys());


### PR DESCRIPTION
## Summary

Add a new `execute-command-wait` MCP tool that executes a command and blocks until completion (or timeout), returning status, exit code and output in a single MCP call.

This eliminates the poll loop on `get-command-result` for short, non-interactive commands (e.g. `ls`, `git status`, quick builds). The caller gets the result immediately instead of issuing `execute-command` followed by repeated `get-command-result` calls.

- Configurable `timeout` (default 30s, max 600s) and `pollInterval` (default 500ms)
- If the timeout elapses before completion, returns status `pending` with the Command ID so the caller can fall back to polling with `get-command-result`
- Does not support `rawMode` or `noEnter` — use `execute-command` for interactive apps and TUI navigation

## Note

When commands are executed consecutively in the same pane, the current static markers (`TMUX_MCP_START` / `TMUX_MCP_DONE_`) can collide, causing incorrect output retrieval. This affects both `execute-command-wait` and the existing `get-command-result`. PR #29 addresses this with unique per-command markers and is a recommended companion change. Happy to rebase on #29 once it's merged and adapt the code to use the unique markers.